### PR TITLE
Direct node manipulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tests/output/
 package-lock.json
 yarn.lock
 **/.reference
+tests/.env

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,9 +15,10 @@
       "env": {
         "TARGET": "jsx"
       },
+      "envFile": "${workspaceRoot}/tests/.env",
       "runtimeArgs": [
-          "-r",
-          "source-map-support/register"
+        "-r",
+        "source-map-support/register"
       ]
     },
     {
@@ -31,9 +32,10 @@
       "env": {
         "TARGET": "js"
       },
+      "envFile": "${workspaceRoot}/tests/.env",
       "runtimeArgs": [
-          "-r",
-          "source-map-support/register"
+        "-r",
+        "source-map-support/register"
       ]
     },
   ]

--- a/packages/modify-style/src/advanced.js
+++ b/packages/modify-style/src/advanced.js
@@ -26,21 +26,21 @@ for(const name in PSEUDO){
     }
 }
 
-// const PascalToDash = x => x.replace(/([A-Z]+)/g, "-$1").toLowerCase();
+const PascalToDash = x => x.replace(/([A-Z]+)/g, "-$1").toLowerCase();
 
 export function css(){
     let body = this.body;
-    if(body && body.isStatement()){
-        if(body.isBlockStatement())
+    if(body){
+        if(body.type == "BlockStatement")
             body = body.get("body");
         else
             body = [body];
 
         for(const item of body){
-            const className = "." + item.node.label.name;
-            if(!item.isLabeledStatement())
+            const className = "." + item.label.name;
+            if(!item.type == "LabeledStatement")
                 throw new Error("css modifier blew up")
-            this.setContingent(className, 5, item.get("body"))
+            this.setContingent(className, 5, item.body)
         }
 
         return;

--- a/packages/plugin-core/index.d.ts
+++ b/packages/plugin-core/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="babel__traverse" />
 import { NodePath as Path, VisitNodeObject } from '@babel/traverse';
-import t, {
+import {
     ArrowFunctionExpression,
     AssignmentExpression,
     DoExpression,
@@ -11,6 +11,7 @@ import t, {
     Program,
     Statement,
     TemplateLiteral,
+    BaseNode,
 } from '@babel/types';
 
 interface BunchOf<T> {
@@ -216,7 +217,7 @@ declare const _default: (options: any) => {
 };
 
 type Visitor<T, S extends StackFrame = StackFrame> = VisitNodeObject<BabelState<S>, T>
-type ParseError = (path: Path, ...args: (string | number)[]) => Error;
+type ParseError = <T extends BaseNode>(node: Path<T> | T, ...args: FlatValue[]) => Error;
 type ModifyAction = (this: ModifyDelegate, ...args: any[]) => ModifierOutput | undefined;
 type FlatValue = string | number | boolean | null;
 type InnerContent = ElementInline | ComponentIf | ComponentFor | Path<Expression> | Expression;

--- a/packages/plugin-core/index.d.ts
+++ b/packages/plugin-core/index.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="babel__traverse" />
-import { NodePath as Path, VisitNodeObject } from '@babel/traverse';
+import { Path as Path, VisitNodeObject } from '@babel/traverse';
 import {
     ArrowFunctionExpression,
     AssignmentExpression,
@@ -50,7 +50,6 @@ declare abstract class AttributeBody extends TraversableBody {
 declare class ElementInline extends AttributeBody {
     readonly primaryName?: string;
     readonly name?: string;
-    readonly multilineContent?: Path<TemplateLiteral>;
     readonly children: InnerContent[];
     readonly modifiers: ElementModifier[]
     readonly explicitTagName?: string;
@@ -68,7 +67,7 @@ declare class ComponentExpression extends ComponentContainer {
 declare class ComponentIf {
     private constructor();
     readonly forks: Array<ComponentConsequent | ComponentIf>;
-    readonly test?: Path<Expression>;
+    readonly test?: Expression;
     readonly context: StackFrame;
     readonly hasElementOutput?: boolean;
     readonly hasStyleOutput?: boolean;
@@ -80,7 +79,7 @@ declare class ComponentConsequent extends ElementInline {
     readonly parentElement: ElementInline;
     readonly parent: ComponentIf;
     readonly path: Path<Statement>;
-    readonly test?: Path<Expression>;
+    readonly test?: Expression;
 }
 declare class ComponentFor extends ComponentContainer {
     private constructor();
@@ -91,17 +90,17 @@ declare class ComponentFor extends ComponentContainer {
 declare abstract class Attribute<T extends Expression = Expression> {
     protected constructor();
     readonly name: string | false;
+    readonly node: T | undefined;
     readonly value: FlatValue | T | undefined;
-    readonly path?: Path<T> | undefined;
     readonly invariant: boolean | undefined;
     readonly overriden?: boolean;
 }
 declare class Prop extends Attribute {
-    constructor(name: string | false, node: FlatValue | Expression | undefined, path?: Path<Expression>);
+    constructor(name: string | false, node: FlatValue | Expression | undefined);
     readonly synthetic?: boolean;
 }
 declare class ExplicitStyle extends Attribute {
-    constructor(name: string | false, node: FlatValue | Expression | undefined, path?: Path<Expression>);
+    constructor(name: string | false, node: FlatValue | Expression | undefined);
     priority: number;
 }
 interface StackFrame {
@@ -140,7 +139,7 @@ declare class ElementModifier extends ModifierBase {
     constructor(
         context: StackFrame, 
         name?: string, 
-        body?: Path<Statement>
+        body?: Statement
     );
     readonly name: string;
     readonly next?: ElementModifier;
@@ -220,8 +219,8 @@ type Visitor<T, S extends StackFrame = StackFrame> = VisitNodeObject<BabelState<
 type ParseError = <T extends BaseNode>(node: Path<T> | T, ...args: FlatValue[]) => Error;
 type ModifyAction = (this: ModifyDelegate, ...args: any[]) => ModifierOutput | undefined;
 type FlatValue = string | number | boolean | null;
-type InnerContent = ElementInline | ComponentIf | ComponentFor | Path<Expression> | Expression;
-type SequenceItem = Attribute | InnerContent | Path<Statement>;
+type InnerContent = ElementInline | ComponentIf | ComponentFor | Expression | Expression;
+type SequenceItem = Attribute | InnerContent | Statement;
 type Modifier = ElementModifier | ContingentModifier;
 
 declare function ParseErrors

--- a/packages/plugin-core/index.d.ts
+++ b/packages/plugin-core/index.d.ts
@@ -170,8 +170,8 @@ interface ModifyDelegate {
 declare abstract class ElementConstruct
     <From extends ElementInline = ElementInline> {
     abstract source: From;
-    abstract Statement<T extends Statement>(item: Path<T> | T): void;
-    abstract Content<T extends Expression = never>(item: Path<T> | T): void;
+    abstract Statement(item: Statement): void;
+    abstract Content(item: Expression): void;
     abstract Child(item: ElementInline): void
     abstract Props(prop: Prop): void;
     abstract Style(style: ExplicitStyle): void;

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@types/babel__template": "^7.0.2",
-    "@types/babel__traverse": "7.0.6",
+    "@types/babel__traverse": "^7.0.7",
     "@types/node": "^11.13.4",
     "rollup": "^1.10.0",
     "rollup-plugin-commonjs": "^9.3.4",

--- a/packages/plugin-core/src/generate/index.ts
+++ b/packages/plugin-core/src/generate/index.ts
@@ -1,4 +1,3 @@
-import { NodePath as Path } from '@babel/traverse';
 import { Expression, isExpression, Statement } from '@babel/types';
 import { Attribute, ComponentFor, ComponentIf, ElementInline, ExplicitStyle, Prop } from 'handle';
 import { SequenceItem } from 'types';
@@ -8,8 +7,8 @@ export abstract class ElementConstruct
 
     abstract source: From;
 
-    abstract Statement<T extends Statement = never>(item: Path<T> | T): void;
-    abstract Content<T extends Expression = never>(item: Path<T> | T): void;
+    abstract Statement(item: Statement): void;
+    abstract Content(item: Expression): void;
     abstract Child(item: ElementInline): void
     abstract Props(prop: Prop): void;
     abstract Style(style: ExplicitStyle): void;
@@ -58,12 +57,10 @@ export abstract class ElementConstruct
             }
 
             else {
-                const node = "node" in item ? item.node : item;
-
-                if(isExpression(node))
-                    this.Content(item as Path<Expression>);
+                if(isExpression(item))
+                    this.Content(item);
                 else
-                    this.Statement(item as Path<Statement>)
+                    this.Statement(item)
             }
         }
 

--- a/packages/plugin-core/src/handle/attributes.ts
+++ b/packages/plugin-core/src/handle/attributes.ts
@@ -92,16 +92,13 @@ export abstract class Attribute<T extends Expression = Expression> {
     overriden?: boolean;
     invariant?: boolean;
     value: FlatValue | T | undefined
-    path?: Path<T>
 
     constructor(
         name: string | false,
-        value: FlatValue | T | undefined, 
-        path?: Path<T>){
+        value: FlatValue | T){
 
         if(name) this.name = name;
         if(value !== undefined) this.value = value;
-        if(path) this.path = path;
 
         if(value === null || typeof value !== "object")
             this.invariant = true

--- a/packages/plugin-core/src/handle/element.ts
+++ b/packages/plugin-core/src/handle/element.ts
@@ -33,7 +33,7 @@ export class ElementInline extends AttributeBody {
     }
 
     ExpressionDefault(path: Path<Expression>){
-        if(inParenthesis(path))
+        if(inParenthesis(path.node))
             this.adopt(path)
         else
             AddElementsFromExpression(path, this);

--- a/packages/plugin-core/src/handle/element.ts
+++ b/packages/plugin-core/src/handle/element.ts
@@ -1,6 +1,21 @@
 import { NodePath as Path } from '@babel/traverse';
-import { AssignmentExpression, Expression, For, IfStatement, TemplateLiteral, UnaryExpression, Statement, VariableDeclaration, DebuggerStatement, FunctionDeclaration, expressionStatement, UpdateExpression, BlockStatement, doExpression, blockStatement } from '@babel/types';
-import { AddElementsFromExpression, StackFrame, ApplyNameImplications } from 'parse';
+import {
+    AssignmentExpression,
+    BlockStatement,
+    blockStatement,
+    DebuggerStatement,
+    doExpression,
+    Expression,
+    expressionStatement,
+    For,
+    FunctionDeclaration,
+    IfStatement,
+    Statement,
+    UnaryExpression,
+    UpdateExpression,
+    VariableDeclaration,
+} from '@babel/types';
+import { AddElementsFromExpression, ApplyNameImplications, StackFrame } from 'parse';
 import { inParenthesis, ParseErrors } from 'shared';
 import { BunchOf, DoExpressive, InnerContent } from 'types';
 
@@ -19,7 +34,6 @@ export class ElementInline extends AttributeBody {
     
     doBlock?: DoExpressive
     primaryName?: string;
-    multilineContent?: Path<TemplateLiteral>;
     children = [] as InnerContent[];
     explicitTagName?: string;
     modifiers = [] as Modifier[];
@@ -34,7 +48,7 @@ export class ElementInline extends AttributeBody {
 
     ExpressionDefault(path: Path<Expression>){
         if(inParenthesis(path.node))
-            this.adopt(path)
+            this.adopt(path.node)
         else
             AddElementsFromExpression(path, this);
     }
@@ -149,7 +163,7 @@ export class ElementInline extends AttributeBody {
         let { name } = left.node;
 
         this.insert(
-            new Prop(name, undefined, path.get("right")));
+            new Prop(name, path.get("right").node));
     }
 }
 

--- a/packages/plugin-core/src/handle/element.ts
+++ b/packages/plugin-core/src/handle/element.ts
@@ -50,7 +50,7 @@ export class ElementInline extends AttributeBody {
         if(inParenthesis(path.node))
             this.adopt(path.node)
         else
-            AddElementsFromExpression(path, this);
+            AddElementsFromExpression(path.node, this);
     }
 
     ElementModifier(mod: ElementModifier){

--- a/packages/plugin-core/src/handle/entry.ts
+++ b/packages/plugin-core/src/handle/entry.ts
@@ -34,11 +34,10 @@ export class ComponentExpression extends ComponentContainer {
     }
 
     add(item: SequenceItem){
-        if(this.forwardTo){
+        if(this.forwardTo)
             this.forwardTo.add(item)
-            return 
-        }
-        super.add(item)
+        else
+            super.add(item)
     }
 
     adopt(child: InnerContent){

--- a/packages/plugin-core/src/handle/iterate.ts
+++ b/packages/plugin-core/src/handle/iterate.ts
@@ -1,12 +1,19 @@
 import { NodePath as Path } from '@babel/traverse';
-import { AssignmentExpression, expressionStatement, For, isVariableDeclaration, isIdentifier, ForXStatement, isForXStatement } from '@babel/types';
+import {
+    AssignmentExpression,
+    For,
+    ForXStatement,
+    isForXStatement,
+    isIdentifier,
+    isVariableDeclaration,
+} from '@babel/types';
 import { StackFrame } from 'parse';
 
 import { ComponentContainer } from './';
 
 export class ComponentFor extends ComponentContainer {
 
-    node: For;
+    node: For
 
     constructor(
         public path: Path<For>, 
@@ -14,16 +21,9 @@ export class ComponentFor extends ComponentContainer {
             
         super(context);
 
-        this.node = path.node;
+        this.node = path.node
         this.name = this.generateName();
-
-        const body = path.get("body");
-        const doBlock = this.handleContentBody(body);
-
-        if(doBlock)
-            body.replaceWith(
-                expressionStatement(doBlock)
-            );
+        this.doBlock = this.handleContentBody(path.node.body);
     }
 
     private generateName(){
@@ -52,7 +52,7 @@ export class ComponentFor extends ComponentContainer {
             return "for"
     }
 
-    AssignmentExpression(path: Path<AssignmentExpression>){
+    AssignmentExpression(path: AssignmentExpression){
         throw new Error("For block cannot accept Assignments");
     }
 

--- a/packages/plugin-core/src/handle/switch.ts
+++ b/packages/plugin-core/src/handle/switch.ts
@@ -8,6 +8,8 @@ import {
     LabeledStatement,
     ReturnStatement,
     Statement,
+    isUnaryExpression,
+    isIdentifier,
 } from '@babel/types';
 import { StackFrame } from 'parse';
 import { ParseErrors, hash } from 'shared';
@@ -216,7 +218,7 @@ export class ComponentConsequent extends ElementInline {
         const uid = hash(this.context.prefix)
 
         //TODO: Discover helpfulness of customized className.
-        let selector = specifyOption(this.test) || `opt${this.index}`;
+        let selector = specifyOption(this.test && this.test.node) || `opt${this.index}`;
         selector += `_${uid}`;
         const parent = context.currentElement!;
 
@@ -239,17 +241,17 @@ export class ComponentConsequent extends ElementInline {
     }
 }
 
-function specifyOption(test?: Path<Expression>){
+function specifyOption(test?: Expression){
     if(!test)
         return "else"
 
     let ref = "if_";
-    if(test.isUnaryExpression({ operator: "!" })){
-        test = test.get("argument");
+    if(isUnaryExpression(test, { operator: "!" })){
+        test = test.argument;
         ref = "not_"
     }
-    if(test.isIdentifier()){
-        const { name } = test.node;
+    if(isIdentifier(test)){
+        const { name } = test;
         return ref + name;
     }
 }

--- a/packages/plugin-core/src/parse/arguments.ts
+++ b/packages/plugin-core/src/parse/arguments.ts
@@ -142,7 +142,7 @@ export const Arguments = new class DelegateTypes {
 
     NumericLiteral(number: Path<NumericLiteral>, sign = 1){
         const { extra: { rawValue, raw } } = number.node as any;
-        if(inParenthesis(number) || !/^0x/.test(raw)){
+        if(inParenthesis(number.node) || !/^0x/.test(raw)){
             if(raw.indexOf(".") > 0)
                 return sign == -1 ? "-" + raw : raw;
             return sign*rawValue;

--- a/packages/plugin-core/src/parse/arguments.ts
+++ b/packages/plugin-core/src/parse/arguments.ts
@@ -1,4 +1,3 @@
-import { NodePath as Path } from '@babel/traverse';
 import {
     ArrowFunctionExpression,
     BinaryExpression,
@@ -16,11 +15,16 @@ import {
     LabeledStatement,
     BlockStatement,
     IfStatement,
+    isNumericLiteral,
+    isExpression,
+    isSpreadElement,
+    isLabeledStatement,
+    isBlockStatement,
+    isExpressionStatement,
+    isIdentifier,
 } from '@babel/types';
 import { inParenthesis, Opts, ParseErrors } from 'shared';
 import { BunchOf, CallAbstraction , IfAbstraction } from 'types'
-
-const { isArray } = Array;
 
 const Error = ParseErrors({
     StatementAsArgument: "Cannot parse statement as a modifier argument!",
@@ -75,21 +79,21 @@ export const Arguments = new class DelegateTypes {
     [type: string]: (...args: any[]) => any;
 
     Parse(
-        element: Path<Expression> | Path<Statement>, 
+        element: Expression | Statement, 
         get?: string): any[] {
 
-        if(element.isExpressionStatement())
-            element = element.get("expression")
+        if(isExpressionStatement(element))
+            element = element.expression
 
         return [].concat(
-            element.isExpression()
+            isExpression(element)
                 ? this.Expression(element)
                 : this.Extract(element)
         )
     }
 
     Extract(
-        element: Path<Expression | Statement>
+        element: Expression | Statement
     ){
         if(element.type in this)
             return this[element.type](element);
@@ -97,52 +101,50 @@ export const Arguments = new class DelegateTypes {
             throw Error.UnknownArgument(element)
     }
 
-    Expression(
-        element: Path<Expression>, 
-        childKey?: string): any {
+    Expression<T extends Expression>(
+        element: T, 
+        childKey?: keyof T): any {
 
         if(childKey)
-            element = element.get(childKey) as typeof element;
-    
-        const { node } = element as any;
+            element = element[childKey] as unknown as T;
 
-        if(node.extra && node.extra.parenthesized)
-            return node;
+        if(inParenthesis(element))
+            return element;
 
         return this.Extract(element)
     }
     
-    Identifier(e: Path<Identifier>){
-        return e.node.name
+    Identifier(e: Identifier){
+        return e.name
     }
 
-    StringLiteral(e: Path<StringLiteral>){
-        return e.node.value
+    StringLiteral(e: StringLiteral){
+        return e.value
     }
 
-    TemplateLiteral(e: Path<TemplateLiteral>) {
-        const { quasis } = e.node;
+    TemplateLiteral(e: TemplateLiteral) {
+        const { quasis } = e;
         if(quasis.length > 1)
-            return e.node;
-        return e.node.quasis[0].value;
+            return e;
+        return e.quasis[0].value;
     }
 
-    UnaryExpression(e: Path<UnaryExpression>){
-        const arg = e.get("argument");
-        if(e.node.operator == "-" && arg.isNumericLiteral())
+    UnaryExpression(e: UnaryExpression){
+        const arg = e.argument;
+        if(e.operator == "-" && isNumericLiteral(arg))
             return this.NumericLiteral(arg, -1)
-        // else if(e.node.operator == "!")
+        // else if(e.operator == "!")
         //     return new DelegateExpression(arg, "verbatim");
         else throw Error.UnaryUseless(e) 
     }
 
-    BooleanLiteral(bool: Path<BooleanLiteral>){
-        return bool.node.value
+    BooleanLiteral(bool: BooleanLiteral){
+        return bool.value
     }
 
-    NumericLiteral(number: Path<NumericLiteral>, sign = 1){
-        const { extra: { rawValue, raw } } = number.node as any;
-        if(inParenthesis(number.node) || !/^0x/.test(raw)){
+    NumericLiteral(number: NumericLiteral, sign = 1){
+        const { extra: { rawValue, raw } } = number as any;
+        if(inParenthesis(number) || !/^0x/.test(raw)){
             if(raw.indexOf(".") > 0)
                 return sign == -1 ? "-" + raw : raw;
             return sign*rawValue;
@@ -154,12 +156,12 @@ export const Arguments = new class DelegateTypes {
         }
     }
 
-    NullLiteral(_e: Path<NullLiteral>){
+    NullLiteral(_e: NullLiteral){
         return null;
     }
 
-    BinaryExpression(binary: Path<BinaryExpression>){
-        const {left, right, operator} = binary.node;
+    BinaryExpression(binary: BinaryExpression){
+        const {left, right, operator} = binary;
         if(operator == "-" 
         && left.type == "Identifier"  
         && right.type == "Identifier" 
@@ -173,44 +175,43 @@ export const Arguments = new class DelegateTypes {
             ]
     }
     
-    SequenceExpression(sequence: Path<SequenceExpression>){
-        return sequence
-            .get("expressions")
+    SequenceExpression(sequence: SequenceExpression){
+        return sequence.expressions
             .map(x => this.Expression(x))
     }
 
-    CallExpression(e: Path<CallExpression>){
-        const callee = e.get("callee");
-        const args = [] as Path<Expression>[];
+    CallExpression(e: CallExpression){
+        const callee = e.callee;
+        const args = [] as Expression[];
         
-        for(const item of e.get("arguments")){
-            if(item.isExpression())
+        for(const item of e.arguments){
+            if(isExpression(item))
                 args.push(item);
-            else if(item.isSpreadElement())
+            else if(isSpreadElement(item))
                 throw Error.ArgumentSpread(item) 
             else 
                 throw Error.UnknownArgument(item) 
         }
 
-        if(!callee.isIdentifier())
+        if(!isIdentifier(callee))
             throw Error.MustBeIdentifier(callee)
 
         const call = args.map(x => this.Expression(x)) as CallAbstraction;
-        call.callee = callee.node.name;
+        call.callee = callee.name;
             
         return call;
     }
 
-    ArrowFunctionExpression(e: Path<ArrowFunctionExpression>): never {
+    ArrowFunctionExpression(e: ArrowFunctionExpression): never {
         throw Error.ArrowNotImplemented(e) 
     }
 
     IfStatement(
-        statement: Path<IfStatement>
+        statement: IfStatement
     ){
-        const alt = statement.get("alternate");
-        const test = statement.get("test");
-        const body = statement.get("body");
+        const alt = statement.alternate;
+        const test = statement.test;
+        const body = statement.consequent;
 
         const data = {
             test: this.Expression(test)
@@ -219,11 +220,9 @@ export const Arguments = new class DelegateTypes {
         if(alt)
             throw Error.ElseNotSupported(test);
 
-        if(isArray(body))
-            throw "?"
-
-        if(body.isBlockStatement()
-        || body.isLabeledStatement()){
+        if(isBlockStatement(body)
+        || isLabeledStatement(body)
+        || isExpressionStatement(body)) {
             Object.assign(data, this.Extract(body))
         }
 
@@ -231,23 +230,23 @@ export const Arguments = new class DelegateTypes {
     }
 
     LabeledStatement(
-        statement: Path<LabeledStatement>
+        statement: LabeledStatement
     ){
         return {
-            [statement.node.label.name]: this.Parse(statement.get("body"))
+            [statement.label.name]: this.Parse(statement.body)
         }
     }
 
     BlockStatement(
-        statement: Path<BlockStatement>
+        statement: BlockStatement
     ){
         const map = {} as BunchOf<any>
 
-        for(const item of statement.get("body")){
-            if(!item.isLabeledStatement())
+        for(const item of statement.body){
+            if(!isLabeledStatement(item))
                 throw Error.ModiferCantParse(statement);
             
-            map[item.node.label.name] = this.Parse(item.get("body"))
+            map[item.label.name] = this.Parse(item.body)
         }
 
         return map;

--- a/packages/plugin-core/src/parse/arguments.ts
+++ b/packages/plugin-core/src/parse/arguments.ts
@@ -20,6 +20,8 @@ import {
 import { inParenthesis, Opts, ParseErrors } from 'shared';
 import { BunchOf, CallAbstraction , IfAbstraction } from 'types'
 
+const { isArray } = Array;
+
 const Error = ParseErrors({
     StatementAsArgument: "Cannot parse statement as a modifier argument!",
     UnaryUseless: "Unary operator here doesn't do anything",
@@ -217,7 +219,7 @@ export const Arguments = new class DelegateTypes {
         if(alt)
             throw Error.ElseNotSupported(test);
 
-        if(Array.isArray(body))
+        if(isArray(body))
             throw "?"
 
         if(body.isBlockStatement()

--- a/packages/plugin-core/src/parse/element.ts
+++ b/packages/plugin-core/src/parse/element.ts
@@ -149,7 +149,7 @@ function CollateLayers(
         if(operator !== ">>")
             throw Error.UnrecognizedBinary(subject);
         else
-        if(inParenthesis(rightHand))
+        if(inParenthesis(rightHand.node))
             throw Error.NoParenChildren(rightHand);
 
         chain.unshift(rightHand);
@@ -261,7 +261,7 @@ function UnwrapExpression(
     target: ElementInline ): Path<Expression> {
 
     let current = expression;
-    while(!inParenthesis(current)) 
+    while(!inParenthesis(current.node)) 
         switch(current.type){
 
         case "TaggedTemplateExpression": {

--- a/packages/plugin-core/src/parse/element.ts
+++ b/packages/plugin-core/src/parse/element.ts
@@ -62,7 +62,7 @@ export function AddElementsFromExpression(
         ? ApplyPassthru 
         : CollateLayers;
 
-    Handler(subject, current, baseAttributes);
+    return Handler(subject, current, baseAttributes);
 }
 
 function IsJustAValue(subject: Expression){
@@ -103,7 +103,7 @@ function ApplyPassthru(
     && identifierName
     && !parent.context.elementMod("$" + identifierName)){
         parent.adopt(subject);
-        return
+        return subject
     }
 
     if(baseAttributes.length > 1
@@ -130,6 +130,7 @@ function ApplyPassthru(
     parent.adopt(container);
 
     ParseProps(baseAttributes, container);
+    return container;
 }
 
 function CollateLayers(
@@ -200,6 +201,7 @@ function CollateLayers(
         baseAttributes.unshift(nestedExpression);
 
     ParseProps(baseAttributes, parent);
+    return parent;
 }
 
 export function ApplyNameImplications(

--- a/packages/plugin-core/src/parse/modifier.ts
+++ b/packages/plugin-core/src/parse/modifier.ts
@@ -7,6 +7,8 @@ import { Arguments } from 'parse';
 
 type ModTuple = [string, ModifyAction, any[] | ModiferBody ];
 
+const { isArray } = Array;
+
 export function ApplyModifier(
     initial: string,
     recipient: Modifier | ElementInline, 
@@ -72,7 +74,7 @@ export function ApplyModifier(
     for(const name in totalOutput.style){
         let item = totalOutput.style[name];
 
-        if(Array.isArray(item)){
+        if(isArray(item)){
             const [ callee, ...args ] = item;
             item = `${callee}(${args.join(" ")})`
         }
@@ -94,7 +96,7 @@ export class ModifyDelegate {
         transform: ModifyAction = PropertyModifierDefault,
         input: any[] | ModiferBody){
 
-        if(Array.isArray(input))
+        if(isArray(input))
             this.arguments = input;
         else {
             this.arguments = Arguments.Parse(input);

--- a/packages/plugin-core/src/parse/modifier.ts
+++ b/packages/plugin-core/src/parse/modifier.ts
@@ -1,4 +1,3 @@
-import { NodePath as Path } from '@babel/traverse';
 import { callExpression, identifier, Statement, stringLiteral } from '@babel/types';
 import { AttributeBody, ContingentModifier, ElementInline, ElementModifier, ExplicitStyle, Modifier } from 'handle';
 
@@ -99,7 +98,7 @@ export class ModifyDelegate {
         if(isArray(input))
             this.arguments = input;
         else {
-            this.arguments = Arguments.Parse(input.node);
+            this.arguments = Arguments.Parse(input);
             this.body = input;
         }
 
@@ -122,7 +121,7 @@ export class ModifyDelegate {
     setContingent(
         contingent: string, 
         priority?: number, 
-        usingBody?: Path<Statement>){
+        usingBody?: Statement){
 
         const { target } = this;
         const mod = new ContingentModifier(
@@ -132,7 +131,7 @@ export class ModifyDelegate {
         )
         
         mod.priority = priority || this.priority;
-        mod.parse(usingBody || this.body!);
+        mod.parseNodes(usingBody || this.body!);
         if(target instanceof ElementInline)
             target.modifiers.push(mod);
         else

--- a/packages/plugin-core/src/parse/modifier.ts
+++ b/packages/plugin-core/src/parse/modifier.ts
@@ -99,7 +99,7 @@ export class ModifyDelegate {
         if(isArray(input))
             this.arguments = input;
         else {
-            this.arguments = Arguments.Parse(input);
+            this.arguments = Arguments.Parse(input.node);
             this.body = input;
         }
 

--- a/packages/plugin-core/src/parse/program.ts
+++ b/packages/plugin-core/src/parse/program.ts
@@ -1,6 +1,6 @@
 import { Program as BabelProgram } from '@babel/types';
 import { ComponentIf, ElementInline, ElementModifier, TraversableBody } from 'handle';
-import { ParseErrors, hash } from 'shared';
+import { ParseErrors, hash, Shared, BabelFile } from 'shared';
 import { BabelState, BunchOf, ModifyAction, Visitor } from 'types';
 
 import * as builtIn from "./builtin"
@@ -14,8 +14,10 @@ const Error = ParseErrors({
 })
 
 export const Program = <Visitor<BabelProgram>>{
-    enter(path, state){
+    enter(path, state: any){
         const context = state.context = new StackFrame(state);
+
+        Shared.currentFile = state.file as BabelFile;
 
         for(const statement of path.get("body"))
             if(statement.isLabeledStatement()){

--- a/packages/plugin-core/src/parse/program.ts
+++ b/packages/plugin-core/src/parse/program.ts
@@ -1,9 +1,9 @@
 import { Program as BabelProgram } from '@babel/types';
 import { ComponentIf, ElementInline, ElementModifier, TraversableBody } from 'handle';
-import { ParseErrors, hash, Shared, BabelFile } from 'shared';
+import { BabelFile, hash, ParseErrors, Shared } from 'shared';
 import { BabelState, BunchOf, ModifyAction, Visitor } from 'types';
 
-import * as builtIn from "./builtin"
+import * as builtIn from './builtin';
 
 const { getPrototypeOf, create, assign } = Object;
 
@@ -33,7 +33,7 @@ export const Program = <Visitor<BabelProgram>>{
                 if(body.isExpressionStatement(body))
                     throw Error.IllegalAtTopLevel(statement)
 
-                const mod = new ElementModifier(context, name, body);
+                const mod = new ElementModifier(context, name, body.node);
                 context.elementMod(mod)
                 statement.remove();
             }

--- a/packages/plugin-core/src/shared.ts
+++ b/packages/plugin-core/src/shared.ts
@@ -1,5 +1,5 @@
 import { NodePath as Path } from '@babel/traverse';
-import { BaseNode, booleanLiteral, Expression } from '@babel/types';
+import { BaseNode, Expression } from '@babel/types';
 import { BunchOf, FlatValue } from 'types';
 
 const { isArray } = Array;
@@ -68,9 +68,9 @@ export function toArray<T> (value: T | T[]): T[] {
         : [];
 }
 
-export function preventDefaultPolyfill(element: Path){
-    element.replaceWith(booleanLiteral(false));
-}
+// export function preventDefaultPolyfill(element: Path){
+//     element.replaceWith(booleanLiteral(false));
+// }
 
 export function inParenthesis(node: Expression): boolean {
     const { extra } = node as any;

--- a/packages/plugin-core/src/shared.ts
+++ b/packages/plugin-core/src/shared.ts
@@ -94,7 +94,7 @@ export function ParseErrors<O extends BunchOf<string>> (register: O) {
                 message.push(segment);
         }
 
-        Errors[error] = <T extends BaseNode>(node: Path<T> | T, ...args: FlatValue[]) => {
+        Errors[error] = (node, ...args) => {
             if("node" in node)
                 node = node.node;
 

--- a/packages/plugin-core/src/shared.ts
+++ b/packages/plugin-core/src/shared.ts
@@ -72,9 +72,9 @@ export function preventDefaultPolyfill(element: Path){
     element.replaceWith(booleanLiteral(false));
 }
 
-export function inParenthesis(path: Path<Expression>): boolean {
-    const node = path.node as any;
-    return node.extra ? node.extra.parenthesized === true : false;
+export function inParenthesis(node: Expression): boolean {
+    const { extra } = node as any;
+    return extra ? extra.parenthesized === true : false;
 }
 
 type ParseError = <T extends BaseNode>(node: Path<T> | T, ...args: FlatValue[]) => Error;

--- a/packages/plugin-core/src/shared.ts
+++ b/packages/plugin-core/src/shared.ts
@@ -77,8 +77,9 @@ export function inParenthesis(path: Path<Expression>): boolean {
     return node.extra ? node.extra.parenthesized === true : false;
 }
 
+type ParseError = <T extends BaseNode>(node: Path<T> | T, ...args: FlatValue[]) => Error;
+
 export function ParseErrors<O extends BunchOf<string>> (register: O) {
-    type ParseError = (path: Path, ...args: FlatValue[]) => Error;
 
     const Errors = {} as BunchOf<ParseError>
 
@@ -93,7 +94,10 @@ export function ParseErrors<O extends BunchOf<string>> (register: O) {
                 message.push(segment);
         }
 
-        Errors[error] = (path: Path, ...args: FlatValue[]) => {
+        Errors[error] = <T extends BaseNode>(node: Path<T> | T, ...args: FlatValue[]) => {
+            if("node" in node)
+                node = node.node;
+
             let quote = "";
             for(const slice of message)
                 quote += (
@@ -101,7 +105,7 @@ export function ParseErrors<O extends BunchOf<string>> (register: O) {
                         ? slice : args[slice as number - 1]
                 )
 
-            return Shared.currentFile.buildCodeFrameError(path.node, quote);
+            return Shared.currentFile.buildCodeFrameError(node, quote);
         }
     }
 

--- a/packages/plugin-core/src/shared.ts
+++ b/packages/plugin-core/src/shared.ts
@@ -1,6 +1,10 @@
 import { NodePath as Path } from '@babel/traverse';
-import { booleanLiteral, Expression } from '@babel/types';
+import { BaseNode, booleanLiteral, Expression } from '@babel/types';
 import { BunchOf, FlatValue } from 'types';
+
+export interface BabelFile {
+    buildCodeFrameError<TError extends Error>(node: BaseNode, msg: string, Error?: new (msg: string) => TError): TError;
+}
 
 export interface SharedSingleton {
     stack: any
@@ -8,6 +12,7 @@ export interface SharedSingleton {
     state: {
         expressive_for_used?: true;
     }
+    currentFile: BabelFile
     styledApplicationComponentName?: string
 }
 
@@ -94,7 +99,7 @@ export function ParseErrors<O extends BunchOf<string>> (register: O) {
                         ? slice : args[slice as number - 1]
                 )
 
-            return path.buildCodeFrameError(quote)
+            return Shared.currentFile.buildCodeFrameError(path.node, quote);
         }
     }
 

--- a/packages/plugin-core/src/shared.ts
+++ b/packages/plugin-core/src/shared.ts
@@ -2,6 +2,16 @@ import { NodePath as Path } from '@babel/traverse';
 import { BaseNode, booleanLiteral, Expression } from '@babel/types';
 import { BunchOf, FlatValue } from 'types';
 
+const { isArray } = Array;
+
+interface Options {
+    compact_vars?: true;
+    env: "native" | "web";
+    output: "js" | "jsx";
+    styleMode: "compile";
+    formatStyles: any;
+}
+
 export interface BabelFile {
     buildCodeFrameError<TError extends Error>(node: BaseNode, msg: string, Error?: new (msg: string) => TError): TError;
 }
@@ -14,14 +24,6 @@ export interface SharedSingleton {
     }
     currentFile: BabelFile
     styledApplicationComponentName?: string
-}
-
-interface Options {
-    compact_vars?: true;
-    env: "native" | "web";
-    output: "js" | "jsx";
-    styleMode: "compile";
-    formatStyles: any;
 }
 
 export const Shared = {} as SharedSingleton;
@@ -60,7 +62,7 @@ export function hash(data: string, length: number = 3){
 
 export function toArray<T> (value: T | T[]): T[] {
     return value !== undefined
-        ? Array.isArray(value) 
+        ? isArray(value) 
             ? value 
             : [value] 
         : [];

--- a/packages/plugin-core/src/types.d.ts
+++ b/packages/plugin-core/src/types.d.ts
@@ -23,7 +23,7 @@ export type InnerContent = Expression | ElementInline | ComponentIf | ComponentF
 
 export type ModifyAction = (this: ModifyDelegate, ...args: any[]) => ModifierOutput | void;
 
-export type ModiferBody = Path<ExpressionStatement | BlockStatement | LabeledStatement | IfStatement>;
+export type ModiferBody = ExpressionStatement | BlockStatement | LabeledStatement | IfStatement;
 
 export type SelectionProvider = (forSelector: string[]) => void
 

--- a/packages/plugin-core/src/types.d.ts
+++ b/packages/plugin-core/src/types.d.ts
@@ -17,9 +17,9 @@ export type Visitor<T, S extends StackFrame = StackFrame> = VisitNodeObject<Babe
 
 export type FlatValue = string | number | boolean | null;
 
-export type SequenceItem = Attribute | InnerContent | Path<Statement>;
+export type SequenceItem = Attribute | InnerContent | Statement;
 
-export type InnerContent = Path<Expression> | Expression | ElementInline | ComponentIf | ComponentFor;
+export type InnerContent = Expression | ElementInline | ComponentIf | ComponentFor;
 
 export type ModifyAction = (this: ModifyDelegate, ...args: any[]) => ModifierOutput | void;
 

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@types/babel__template": "^7.0.2",
-    "@types/babel__traverse": "7.0.6",
+    "@types/babel__traverse": "^7.0.7",
     "@types/node": "^11.13.4",
     "rollup": "^1.10.0",
     "rollup-plugin-commonjs": "^9.3.4",

--- a/packages/plugin-react/src/generate/es5.ts
+++ b/packages/plugin-react/src/generate/es5.ts
@@ -59,16 +59,19 @@ export class GenerateES extends GenerateReact {
         children = [] as ContentLike[],
         key?: Expression | false
     ){
+        const properties = [] as ObjectProperty[];
+        if(key)
+            properties.push(
+                objectProperty(
+                    identifier("key"), key
+                )
+            )
+
         return (
             callExpression(
                 this.Create, [
                 this.Fragment,
-                objectExpression([
-                    objectProperty(
-                        identifier("key"),
-                        key ? key : identifier("undefined")
-                    )
-                ]),
+                objectExpression(properties),
                 ...this.recombineChildren(children)
             ]) 
         )

--- a/packages/plugin-react/src/generate/jsx.ts
+++ b/packages/plugin-react/src/generate/jsx.ts
@@ -117,16 +117,25 @@ export class GenerateJSX extends GenerateReact {
     
         while(true) {
             const value = quasis[i].value.cooked as string;
-            if(value)
+            if(value){
+                let text: JSXContent | undefined;
                 if(/\n/.test(value))
-                    if(acceptBr){
-                        const chunks = breakdown(node);
-                        return this.recombineMultilineJSX(chunks);
-                    }
-                    else {
-                        dedent(node);
-                        return [ jsxExpressionContainer(node) ]
-                    }
+                    if(acceptBr)
+                        return this.recombineMultilineJSX(node);
+                    else 
+                        return [ 
+                            jsxExpressionContainer(
+                                dedent(node)
+                            )
+                        ]
+                else if(/[{}]/.test(value))
+                    jsxExpressionContainer(
+                        stringLiteral(value))
+                else 
+                    text = jsxText(value);
+
+                acc.push(text!)
+            }
     
             if(i in expressions)
                 acc.push(
@@ -139,9 +148,9 @@ export class GenerateJSX extends GenerateReact {
     }
 
     private recombineMultilineJSX(
-        chunks: Array<string | Expression>
+        node: TemplateLiteral
     ): JSXContent[] {
-        return chunks.map(chunk => {
+        return breakdown(node).map(chunk => {
             if(chunk === "\n")
                 return jsxElement(
                     jsxOpeningElement(jsxIdentifier("br"), [], true),

--- a/packages/plugin-react/src/generate/syntax.ts
+++ b/packages/plugin-react/src/generate/syntax.ts
@@ -43,8 +43,8 @@ export function expressionValue(item: Prop | ExplicitStyle){
             numericLiteral(value) :
         typeof value === "boolean" ?
             booleanLiteral(value) :
-        value === undefined && item.path ?
-            item.path.node :
+        value === undefined && item.node ?
+            item.node :
         typeof value === "object" ?
             value || nullLiteral() :
             identifier("undefined")

--- a/packages/plugin-react/src/handle/element.ts
+++ b/packages/plugin-react/src/handle/element.ts
@@ -203,8 +203,8 @@ export class ElementReact<T extends ElementInline = ElementInline>
             case "className": {
                 let { value } = item;
 
-                if(!value && item.path)
-                    value = item.path.node;
+                if(!value && item.node)
+                    value = item.node;
 
                 if(value && typeof value == "object")
                     if(isStringLiteral(value))

--- a/packages/plugin-react/src/handle/element.ts
+++ b/packages/plugin-react/src/handle/element.ts
@@ -1,3 +1,4 @@
+import { NodePath as Path } from '@babel/traverse';
 import {
     callExpression,
     Expression,
@@ -21,7 +22,7 @@ import {
     SequenceItem,
 } from '@expressive/babel-plugin-core';
 import { AttributeES, AttributeStack, ElementIterate, ElementSwitch, expressionValue } from 'internal';
-import { ContentLike, Path, PropData, StackFrame } from 'types';
+import { ContentLike, PropData, StackFrame } from 'types';
 
 export class ElementReact<T extends ElementInline = ElementInline>
     extends ElementConstruct<T>{

--- a/packages/plugin-react/src/handle/element.ts
+++ b/packages/plugin-react/src/handle/element.ts
@@ -1,4 +1,3 @@
-import { NodePath as Path } from '@babel/traverse';
 import {
     callExpression,
     Expression,
@@ -193,7 +192,6 @@ export class ElementReact<T extends ElementInline = ElementInline>
             this.style_static.push(item);
         else
             this.style.insert(item)
-        
     }
 
     Props(item: Prop){
@@ -229,10 +227,7 @@ export class ElementReact<T extends ElementInline = ElementInline>
         this.adopt(new ElementReact(item));
     }
 
-    Content(item: Path<Expression> | Expression){
-        if("node" in item)
-            item = item.node;
-
+    Content(item: Expression){
         this.adopt(item);
     }
 

--- a/packages/plugin-react/src/handle/iterate.ts
+++ b/packages/plugin-react/src/handle/iterate.ts
@@ -32,7 +32,7 @@ export class ElementIterate
 
     constructor(source: ComponentFor){
         super(source);
-        this.type = source.path.type as any;
+        this.type = source.node.type as any;
     };
     
     toExpression(Generator: GenerateReact): CallExpression {

--- a/packages/plugin-react/src/handle/switch.ts
+++ b/packages/plugin-react/src/handle/switch.ts
@@ -29,7 +29,7 @@ function reducerAlgorithm(
     let sum: Expression | undefined;
 
     for(const cond of forks){
-        const test = cond.test && cond.test.node;
+        const test = cond.test;
         const product = predicate(cond);
 
         if(sum && test)

--- a/packages/plugin-react/src/regenerate/module.ts
+++ b/packages/plugin-react/src/regenerate/module.ts
@@ -1,9 +1,9 @@
-import { NodePath as Path } from '@babel/traverse';
+import { Path as Path } from '@babel/traverse';
 import { Program as ProgramNode } from '@babel/types';
 import { BabelState, DoExpressive, Modifier } from '@expressive/babel-plugin-core';
 import { ExternalsManager, GenerateES, GenerateJSX, ImportManager, writeProvideStyleStatement } from 'internal';
 import { relative } from 'path';
-import { StylesRegistered, Visitor } from 'types';
+import { Visitor } from 'types';
 
 import { RequirementManager } from './scope';
 
@@ -57,7 +57,6 @@ export const Program = <Visitor<ProgramNode>> {
 export class Module {
 
     modifiersDeclared = new Set<Modifier>()
-    styleBlocks = [] as StylesRegistered[];
     lastInsertedElement?: Path<DoExpressive>;
 
     constructor(

--- a/packages/plugin-react/src/regenerate/scope.ts
+++ b/packages/plugin-react/src/regenerate/scope.ts
@@ -1,4 +1,4 @@
-import { NodePath as Path, Scope } from '@babel/traverse';
+import { Path as Path, Scope } from '@babel/traverse';
 import {
     Expression,
     Identifier,

--- a/packages/plugin-react/src/types.ts
+++ b/packages/plugin-react/src/types.ts
@@ -8,16 +8,18 @@ import {
     JSXSpreadChild,
     JSXText,
 } from '@babel/types';
-import { ExplicitStyle, StackFrame as CoreStackFrame, Visitor as CoreVisitor } from '@expressive/babel-plugin-core';
+import { StackFrame as CoreStackFrame, Visitor as CoreVisitor } from '@expressive/babel-plugin-core';
 import { ElementReact } from 'handle/element';
 import { ElementIterate } from 'handle/iterate';
 import { ElementSwitch } from 'handle/switch';
-import { ExternalsManager } from 'regenerate/scope';
 import { Module } from 'regenerate/module';
+import { ExternalsManager } from 'regenerate/scope';
 
 export type JSXContent = JSXElement | JSXFragment | JSXExpressionContainer | JSXText | JSXSpreadChild;
 export type Attributes = JSXAttribute | JSXSpreadAttribute;
 export type InnerJSX = ElementReact | ElementSwitch | ElementIterate;
+export type ContentLike = ElementReact | ElementSwitch | ElementIterate | Expression;
+export type Visitor<T> = CoreVisitor<T, StackFrame>
 
 export const IsLegalAttribute = /^[a-zA-Z_][\w-]*$/;
 export const IsLegalIdentifier = /^[a-zA-Z_]\w*$/;
@@ -41,19 +43,7 @@ export interface BabelState {
     filename: string;
 }
 
-export type Visitor<T> = CoreVisitor<T, StackFrame>
-
-export type PropData = {
-    name: string | false | undefined, 
+export interface PropData {
+    name: string | false | undefined
     value: Expression
-}
-
-export type ContentLike = ElementReact | ElementSwitch | ElementIterate | Expression;
-
-export interface StylesRegistered
-    extends Array<ExplicitStyle> {
-
-    selector: string;
-    query?: string;
-    priority?: number;
 }

--- a/tests/bin/debug.js
+++ b/tests/bin/debug.js
@@ -2,6 +2,7 @@ const gulp = require("gulp");
 const babel = require("gulp-babel");
 const replace = require('gulp-replace');
 const prettier = require("gulp-prettier");
+const prettyjson = require("prettyjson")
 
 const printError = require("./error")
 const babelrc = require("./babel.config")
@@ -42,7 +43,10 @@ gulp.task('xjs', (done) => {
   gulp.src([inDir])
       .pipe(babel({ babelrc: false, ...babelrc }))
       .on('error', function(e){
-        printError(e);
+        // printError(e);
+        console.error(
+          prettyjson.render(e).replace(/\n/g, "\n  ")
+        )
         console.log("\n\Watch task has crashed, restart session to resume.")
       })
       .pipe(prettier(prettyConfig))

--- a/tests/bin/debug.js
+++ b/tests/bin/debug.js
@@ -6,9 +6,10 @@ const prettier = require("gulp-prettier");
 const printError = require("./error")
 const babelrc = require("./babel.config")
 
-const {
-  INPUT = "input/",
-  OUT = "output/"
+let {
+  TEST_INPUT,
+  TEST_OUTPUT,
+  TEST_DEFAULT
 } = process.env;
 
 const statementLineSpacing = () =>
@@ -17,8 +18,14 @@ const statementLineSpacing = () =>
 const jsxReturnSpacing = () =>
     replace(/^(.+?[^{])\n(\s+return (?=\(|<))/gm, "$1\n\n$2")
 
-const inDir = INPUT.replace(/\/$/, "").concat("/*.js");
-const outDir = OUT.replace(/\/$/, "");
+if(TEST_DEFAULT || !TEST_INPUT)
+  TEST_INPUT = "input/"
+
+if(TEST_DEFAULT || !TEST_OUTPUT)
+  TEST_OUTPUT = "output/"
+
+const inDir = TEST_INPUT.replace(/\/$/, "").concat("/*.js");
+const outDir = TEST_OUTPUT.replace(/\/$/, "");
 
 const prettyConfig = { 
   singleQuote: false, 

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,6 +8,7 @@
     "gulp-babel": "^8.0.0",
     "gulp-prettier": "^2.0.0",
     "gulp-replace": "^1.0.0",
+    "prettyjson": "^1.2.1",
     "source-map-support": "^0.5.10"
   }
 }


### PR DESCRIPTION
Simplify the internals by reducing dependance on `<NodePath>`. Decreases compilations times too because objects have less inference required.